### PR TITLE
use new cromwell-additions script

### DIFF
--- a/create-custom-ami.yaml
+++ b/create-custom-ami.yaml
@@ -101,7 +101,7 @@ Resources:
               command:
                 Fn::If:
                   - UseCromwell
-                  - !Join [" ", ["sh", "/opt/ecs-patches/ecs-patches.sh"]]
+                  - !Join [" ", ["sh", "/opt/ecs-patches/ecs-additions-cromwell.sh"]]
                   - echo "OK"
               env:
                 PATH: "/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin"


### PR DESCRIPTION
This script has more error checking to verify that container
installs and modifications needed for cromwell to run are
successful.