### PR TITLE
add ssm-agent to AMI

### DIFF
--- a/create-custom-ami-existing-vpc.yaml
+++ b/create-custom-ami-existing-vpc.yaml
@@ -63,6 +63,8 @@ Resources:
       AWS::CloudFormation::Init:
         config:
           packages:
+            rpm:
+              ssm-agent: "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm"
             yum:
               jq: []
               btrfs-progs: []

--- a/create-custom-ami-existing-vpc.yaml
+++ b/create-custom-ami-existing-vpc.yaml
@@ -30,6 +30,9 @@ Parameters:
     Default: /aws/service/ecs/optimized-ami/amazon-linux/recommended/image_id
     AllowedValues:
       - /aws/service/ecs/optimized-ami/amazon-linux/recommended/image_id
+  KeyName:
+    Type: AWS::EC2::KeyPair::KeyName
+    Default: GENERAL.NONE
   AMIType:
     Type: String
     Description: The type of AMI you want to create
@@ -110,6 +113,7 @@ Resources:
     Properties:
       ImageId: !Ref LatestECSAMI
       InstanceType: t2.large
+      KeyName: !Ref KeyName
       Tags:
         - Key: Name
           Value: genomics-base-ami

--- a/create-custom-ami-new-vpc.yaml
+++ b/create-custom-ami-new-vpc.yaml
@@ -24,6 +24,9 @@ Parameters:
     Default: /aws/service/ecs/optimized-ami/amazon-linux/recommended/image_id
     AllowedValues:
       - /aws/service/ecs/optimized-ami/amazon-linux/recommended/image_id
+  KeyName:
+    Type: AWS::EC2::KeyPair::KeyName
+    Default: GENERAL.NONE
   AMIType:
     Type: String
     Description: The type of AMI you want to create

--- a/create-custom-ami-new-vpc.yaml
+++ b/create-custom-ami-new-vpc.yaml
@@ -107,6 +107,8 @@ Resources:
       AWS::CloudFormation::Init:
         config:
           packages:
+            rpm:
+              ssm-agent: "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm"
             yum:
               jq: []
               btrfs-progs: []


### PR DESCRIPTION
Adds installation of the SSM agent to the AMI so that launched instances can be managed via the SSM Console.